### PR TITLE
Fix the docker compose up command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ cd examor
 #### Run docker compose
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 > Please make sure Docker is installed on your local machine, and ports `51717`, `51818`, and `52020` are available on your local host
@@ -147,7 +147,7 @@ When starting the project, the application checks for updates. If an update is r
 
 2. Pull the latest remote code updates to refresh your local project.
 
-3. Delete the existing Docker container and rebuild the project with the `docker-compose run` command to incorporate the latest changes.
+3. Delete the existing Docker container and rebuild the project with the `docker compose run` command to incorporate the latest changes.
 
 4. Once the build is successful, navigate to the personal settings page, click the **Import File** button, and re-import the backed-up data into the project.
 

--- a/docs/zh-doc.md
+++ b/docs/zh-doc.md
@@ -46,7 +46,7 @@ cd examor
 #### 使用 docker compose 启动项目
 
 ```bash
-docker-compose up
+docker compose up
 ```
 
 > 请确保您的本机安装了 Docker，并且本地的 `51717`、`51818` 和 `52020` 端口没有被占用
@@ -132,7 +132,7 @@ docker-compose up
 
 2. 重新拉取更新最新的远程代码，更新本地的项目
 
-3. 删除原有的 docker 容器，使用 `docker-compose run` 命令重新构建最新的项目
+3. 删除原有的 docker 容器，使用 `docker compose run` 命令重新构建最新的项目
 
 4. 构建成功后进入个人配置页面，点击 **文件导入** 按钮，将备份过的数据重新导入到项目中
 


### PR DESCRIPTION
Now docker-compose is deprecated, you can not run the container with `docker-compose up` or `docker-compose run`, it runs as a plugin for docker. 
